### PR TITLE
This pr makes this applet work on leste

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -10,7 +10,7 @@ volume_status_menu_item_la_LIBADD = $(STATUS_MENU_VOLUME_LIBS) -lm
 volume_status_menu_item_la_SOURCES = item.c
 
 propertydir = $(datadir)/maemo-statusmenu-volume
-property_DATA = volume_steps_update
+property_DATA = sinks.ini
 
 hildonstatusmenudesktopentry_DATA = volume.desktop
 

--- a/src/item.c
+++ b/src/item.c
@@ -21,7 +21,7 @@
 #include <math.h>
 #include <string.h>
 
-#define KEY_FILE "/usr/share/maemo-statusmenu-volume/volume_steps_update"
+#define KEY_FILE "/usr/share/maemo-statusmenu-volume/sinks.ini"
 
 #define SOUND_STATUS_MENU_TYPE_ITEM (sounds_status_menu_item_get_type())
 #define SOUND_STATUS_MENU_ITEM(obj) (G_TYPE_CHECK_INSTANCE_CAST ((obj), \

--- a/src/item.c
+++ b/src/item.c
@@ -69,7 +69,6 @@ struct _SoundsStatusMenuItemPrivate
   gboolean portrait;
   guint8 normal_channels;
   gchar *normal_sink_name;
-  gchar *normal_sink_property;
   gchar *incall_sink_property;
   gint normal_volume_num_steps;
   gint incall_volume_num_steps;
@@ -516,16 +515,6 @@ get_sinks(SoundsStatusMenuItemPrivate *priv)
     if (error)
     {
       g_warning("unable to get normal->sink_name [%s]", error->message);
-      g_error_free(error);
-      error = NULL;
-    }
-
-    priv->normal_sink_property =
-        g_key_file_get_string(key_file, "normal", "sink_property", &error);
-
-    if (error)
-    {
-      g_warning("unable to get normal->sink_property [%s]", error->message);
       g_error_free(error);
       error = NULL;
     }
@@ -1030,7 +1019,6 @@ prop_sink_info_cb(pa_context *c, const pa_sink_info *i, int eol, void *userdata)
   if (eol)
     return;
 
-  prop_normal = pa_proplist_gets(i->proplist, priv->normal_sink_property);
   prop_incall = pa_proplist_gets(i->proplist, priv->incall_sink_property);
 
   parse_tuning_property(prop_normal, &priv->normal_volume_num_steps,

--- a/src/item.c
+++ b/src/item.c
@@ -88,7 +88,7 @@ struct _SoundsStatusMenuItemPrivate
   gboolean swap_on_rotate;
   gboolean native_landscape;
   gboolean display_on;
-  gboolean keys_are_grabed;
+  gboolean keys_are_grabbed;
 };
 
 struct _SoundsStatusMenuItem
@@ -131,7 +131,7 @@ grab_keys(SoundsStatusMenuItemPrivate *priv)
            GrabModeAsync);
   XGrabKey(GDK_DISPLAY(), X_KEYCODE_DOWN, AnyModifier, w, True, GrabModeAsync,
            GrabModeAsync);
-  priv->keys_are_grabed = TRUE;
+  priv->keys_are_grabbed = TRUE;
 }
 
 static void
@@ -139,7 +139,7 @@ ungrab_keys(SoundsStatusMenuItemPrivate *priv)
 {
   XUngrabKey(GDK_DISPLAY(), X_KEYCODE_UP, AnyModifier, GDK_ROOT_WINDOW());
   XUngrabKey(GDK_DISPLAY(), X_KEYCODE_DOWN, AnyModifier, GDK_ROOT_WINDOW());
-  priv->keys_are_grabed = FALSE;
+  priv->keys_are_grabbed = FALSE;
 }
 
 static Window
@@ -365,7 +365,7 @@ dbus_filter(DBusConnection *connection, DBusMessage *message, void *user_data)
                               DBUS_TYPE_INT32, &value,
                               DBUS_TYPE_INVALID))
     {
-      if (priv->keys_are_grabed &&
+      if (priv->keys_are_grabbed &&
         !priv->volume_changed &&
         (hw_keycode == HW_KEYCODE_UP || hw_keycode == HW_KEYCODE_DOWN) &&
         value)
@@ -442,7 +442,7 @@ sounds_status_menu_item_dispose(GObject *object)
 {
   SoundsStatusMenuItem *menu_item = SOUND_STATUS_MENU_ITEM(object);
   SoundsStatusMenuItemPrivate *priv = SOUND_STATUS_MENU_ITEM_PRIVATE(menu_item);
-  
+
   gdk_window_remove_filter(0, gdk_filter_func, menu_item);
 
   if (priv->pa_context)
@@ -1241,7 +1241,7 @@ sounds_status_menu_item_init(SoundsStatusMenuItem *menu_item)
   priv->normal_channels = 0;
   priv->swap_on_rotate = FALSE;
   priv->display_on = TRUE;
-  priv->keys_are_grabed = FALSE;
+  priv->keys_are_grabbed = FALSE;
   priv->native_landscape = FALSE;
 
   get_sinks(priv);

--- a/src/sinks.ini
+++ b/src/sinks.ini
@@ -1,0 +1,7 @@
+[normal]
+sink_name=alsa_output.0.HiFi__hw_Audio_0__sink
+[incall]
+sink_property=x-maemo.alsa_sink.alt_mixer_tuning
+[behavior]
+swap_on_rotate=1
+native_is_landscape=1

--- a/src/volume_steps_update
+++ b/src/volume_steps_update
@@ -1,5 +1,6 @@
 [normal]
-sink_name=sink.hw0
-sink_property=x-maemo.alsa_sink.mixer_tuning
+sink_name=alsa_output.0.HiFi__hw_Audio_0__sink
 [incall]
 sink_property=x-maemo.alsa_sink.alt_mixer_tuning
+[behavior]
+swap_on_rotate=0

--- a/src/volume_steps_update
+++ b/src/volume_steps_update
@@ -1,6 +1,0 @@
-[normal]
-sink_name=alsa_output.0.HiFi__hw_Audio_0__sink
-[incall]
-sink_property=x-maemo.alsa_sink.alt_mixer_tuning
-[behavior]
-swap_on_rotate=0


### PR DESCRIPTION
So this applet used to set a stream volume proprietary on some n900 hw specific streams (this was configurable)
* Now it sets the volume of the (configurable) stream, this allows ucm based systems to work
* Should set HiFi volume normally and VoiceCall volume in a call, if call mode is set in mce
* Call mode is untested
* This applet grabs the volume keys if _HILDON_ZOOM_KEY_ATOM is not set on the root window preventing windows from getting these keys 
   * The application also only changes volume if this atom is set
   * This is a terrible implementation beacuse any application can set this atom and then crash, amoung other problems
   * The new input method still dose replicate this behavior
* New input method:
   * previously this applet used the events from the afore mentioned XGrabKey to set the volume. This is insufficient as tklock will XGrabKeyboard breaking the XGrabKey when the device is locked.
   * to circumvent this nokia added a dbus protocol to tklock that tunneled the keys to this applet
   * this however is an unworkable solution:
       * on fremantle mce uses a vendor kernel interface to disable input devices while locked
       * on leste mce uses XInput to disable input devices while locked
       * to ensure that tklock/xorg none the less gets volume key events freemantle mce avoids disabling the input device that contains "switches"
       * this however assumes that the volume keys are on a seperate input device. this is only true on n900
       * further we cannot give xorg any key events anyways beacuse this would make it wake the display
     * Solution:
        * implement the tklock dbus interface in mce (renamed) and have mce filter for volume keys
        * make the volume applet exclusive use this interface and ignore events it gets from the key grab
        * make the volume applet ignore events from mce when _HILDON_ZOOM_KEY_ATOM is set and the display is on
        * grab behavior is retained to filter volume keys form applications in other cases